### PR TITLE
remove of auth header, use dns to work with local and remote clusters

### DIFF
--- a/skyramp/grpc/sample-clients/local/golang/cmd/cart/addCart.go
+++ b/skyramp/grpc/sample-clients/local/golang/cmd/cart/addCart.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 
 	pb "gcp/demo"
+
 	"google.golang.org/grpc"
 )
 
 func main() {
-
-	conn, err := grpc.Dial("127.0.0.1:80", grpc.WithInsecure(), grpc.WithAuthority("cart-service-port7070.demo.skyramp.test"))
+	conn, err := grpc.Dial("cart-service-port7070.demo.skyramp.test:80", grpc.WithInsecure())
 	if err != nil {
 		fmt.Printf("Could not connect: %v\n", err)
 	}

--- a/skyramp/grpc/sample-clients/local/golang/cmd/order/placeOrder.go
+++ b/skyramp/grpc/sample-clients/local/golang/cmd/order/placeOrder.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 
 	pb "gcp/demo"
+
 	"google.golang.org/grpc"
 )
 
 func main() {
-
-	conn, err := grpc.Dial("127.0.0.1:80", grpc.WithInsecure(), grpc.WithAuthority("checkout-service-port5050.demo.skyramp.test"))
+	conn, err := grpc.Dial("checkout-service-port5050.demo.skyramp.test:80", grpc.WithInsecure())
 	if err != nil {
 		fmt.Printf("Could not connect: %v\n", err)
 	}

--- a/skyramp/grpc/sample-clients/local/python/addCart.py
+++ b/skyramp/grpc/sample-clients/local/python/addCart.py
@@ -7,10 +7,9 @@ from demo_pb2 import AddItemRequest, CartItem
 from demo_grpc import CartServiceStub
 
 async def main():
-    async with Channel('127.0.0.1', 80) as channel:
+    async with Channel('cart-service-port7070.demo.skyramp.test', 80) as channel:
         # Set HTTP2 authority header so the request can be routed
         # correctly by Skyramp
-        channel._authority = "cart-service-port7070.demo.skyramp.test"
         cart = CartServiceStub(channel)
 
         reply = await cart.AddItem(AddItemRequest(user_id='abcde', item=CartItem(product_id="OLJCESPC7Z", quantity=1)))

--- a/skyramp/grpc/sample-clients/local/python/placeOrder.py
+++ b/skyramp/grpc/sample-clients/local/python/placeOrder.py
@@ -7,10 +7,9 @@ from demo_pb2 import PlaceOrderRequest, Address, CreditCardInfo
 from demo_grpc import CheckoutServiceStub
 
 async def main():
-    async with Channel('127.0.0.1', 80) as channel:
+    async with Channel('checkout-service-port5050.demo.skyramp.test', 80) as channel:
         # Set HTTP2 authority header so the request can be routed
         # correctly by Skyramp
-        channel._authority = "checkout-service-port5050.demo.skyramp.test"
         checkout = CheckoutServiceStub(channel)
 
         reply = await checkout.PlaceOrder(PlaceOrderRequest(

--- a/skyramp/rest/sample-clients/local/curl/add_cart.sh
+++ b/skyramp/rest/sample-clients/local/curl/add_cart.sh
@@ -3,7 +3,6 @@
 set -e
 
 curl -X 'POST' 'http://cart-service-port60000.demo.skyramp.test/cart/user_id/abcde' \
-  --resolve cart-service-port60000.demo.skyramp.test:80:127.0.0.1 \
   -H 'accept: application/json' \
   -H 'content-type: application/json' \
   -d '{

--- a/skyramp/rest/sample-clients/local/curl/checkout.sh
+++ b/skyramp/rest/sample-clients/local/curl/checkout.sh
@@ -4,7 +4,6 @@
 set -e
 
 curl -X 'POST' 'http://cart-service-port60000.demo.skyramp.test/cart/user_id/abcde' \
-  --resolve cart-service-port60000.demo.skyramp.test:80:127.0.0.1 \
   -H 'accept: application/json' \
   -H 'content-type: application/json' \
   -d '{
@@ -15,7 +14,6 @@ curl -X 'POST' 'http://cart-service-port60000.demo.skyramp.test/cart/user_id/abc
 
 curl -X 'POST' \
   'http://checkout-service-port60000.demo.skyramp.test/checkout' \
-  --resolve checkout-service-port60000.demo.skyramp.test:80:127.0.0.1 \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
   -d '{

--- a/skyramp/rest/sample-clients/local/curl/delete_cart.sh
+++ b/skyramp/rest/sample-clients/local/curl/delete_cart.sh
@@ -3,6 +3,5 @@
 set -e
 
 curl -X 'DELETE' \
-   --resolve cart-service-port60000.demo.skyramp.test:80:127.0.0.1 \
   'http://cart-service-port60000.demo.skyramp.test/cart/user_id/abcde' \
    -H 'accept: application/json'

--- a/skyramp/rest/sample-clients/local/curl/get_product.sh
+++ b/skyramp/rest/sample-clients/local/curl/get_product.sh
@@ -5,6 +5,5 @@ set -e
 
 curl -X 'GET' \
   'http://product-catalog-service-port60000.demo.skyramp.test/get-product?product_id=OLJCESPC7Z' \
-    --resolve product-catalog-service-port60000.demo.skyramp.test:80:127.0.0.1 \
   -H 'accept: application/json'
 

--- a/skyramp/rest/sample-clients/local/curl/list_cart.sh
+++ b/skyramp/rest/sample-clients/local/curl/list_cart.sh
@@ -4,5 +4,4 @@ set -e
 
 curl -X 'GET' \
   'http://cart-service-port60000.demo.skyramp.test/cart/user_id/abcde' \
-   --resolve cart-service-port60000.demo.skyramp.test:80:127.0.0.1 \
    -H 'accept: application/json'

--- a/skyramp/rest/sample-clients/local/curl/list_products.sh
+++ b/skyramp/rest/sample-clients/local/curl/list_products.sh
@@ -4,5 +4,4 @@ set -e
 
 curl -X 'GET' \
   'http://product-catalog-service-port60000.demo.skyramp.test/get-products' \
-  --resolve product-catalog-service-port60000.demo.skyramp.test:80:127.0.0.1 \
   -H 'accept: application/json'

--- a/skyramp/rest/sample-clients/local/curl/payment_service.sh
+++ b/skyramp/rest/sample-clients/local/curl/payment_service.sh
@@ -4,7 +4,6 @@ set -e
 
 curl -X 'POST' \
   'http://payment-service-port60000.demo.skyramp.test/charge' \
-  --resolve payment-service-port60000.demo.skyramp.test:80:127.0.0.1 \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
   -d '{

--- a/skyramp/rest/sample-clients/local/curl/search_product.sh
+++ b/skyramp/rest/sample-clients/local/curl/search_product.sh
@@ -4,5 +4,4 @@ set -e
 
 curl -X 'GET' \
   'http://product-catalog-service-port60000.demo.skyramp.test/search-products?query=kitchen' \
-    --resolve product-catalog-service-port60000.demo.skyramp.test:80:127.0.0.1 \
   -H 'accept: application/json'

--- a/skyramp/rest/sample-clients/local/curl/send_order_confirmation.sh
+++ b/skyramp/rest/sample-clients/local/curl/send_order_confirmation.sh
@@ -3,7 +3,6 @@
 
 curl -X 'POST' \
   'http://email-service-port60000.demo.skyramp.test/send-order-confirmation' \
-   --resolve email-service-port60000.demo.skyramp.test:80:127.0.0.1 \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
   -d '{

--- a/skyramp/rest/sample-clients/local/curl/shipping_service_get_quote.sh
+++ b/skyramp/rest/sample-clients/local/curl/shipping_service_get_quote.sh
@@ -4,7 +4,6 @@ set -e
 
 curl -X 'PUT' \
   'http://shipping-service-port60000.demo.skyramp.test/get-quote' \
-    --resolve shipping-service-port60000.demo.skyramp.test:80:127.0.0.1 \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
   -d '{

--- a/skyramp/rest/sample-clients/local/curl/shipping_service_ship_order.sh
+++ b/skyramp/rest/sample-clients/local/curl/shipping_service_ship_order.sh
@@ -4,7 +4,6 @@ set -e
 
 curl -X 'PUT' \
   'http://shipping-service-port60000.demo.skyramp.test/ship-order' \
-  --resolve shipping-service-port60000.demo.skyramp.test:80:127.0.0.1 \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
   -d '{


### PR DESCRIPTION
Requires local name server that resolves domain skyramp.test to k8s ingress controller 

Signed-off-by: pellepedro <Per.Pettersson@gmail.com>